### PR TITLE
Clean up Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
-source "http://rubygems.org"
+source "http://bundler-api.herokuapp.com"
 
 gem 'jasmine', '1.1.0'
 gem 'JSHint', :git => 'https://github.com/rquinlivan/jshint-gem.git'
 gem 'rake'
-gem 'rake-pipeline', :git => 'https://github.com/livingsocial/rake-pipeline.git'
-gem 'rake-pipeline-web-filters', :git => 'https://github.com/wycats/rake-pipeline-web-filters.git'
-gem 'rails', ">= 3.0" #for some reason travis-ci.org wants this
+gem 'rake-pipeline', '~> 0.7.0'
+gem 'rake-pipeline-web-filters', '~> 0.7.0'


### PR DESCRIPTION
- Use the Heroku mirror to reduce load on the rubygems.org API
- Drop the rails dependency
- Specify proper gem releases rather than pointing to git repos

cc: @shajith @vcekov 
