### PR TITLE
Ember.Resource create: don't call updateWithApiData if only data.id is present

### DIFF
--- a/spec/javascripts/associationsSpec.js
+++ b/spec/javascripts/associationsSpec.js
@@ -14,6 +14,26 @@ describe('associations', function() {
     }
   });
 
+  describe("has one remote", function() {
+    var subject;
+
+    beforeEach(function() {
+      var Person = Ember.Resource.define({
+        schema: {
+          name: String,
+          address: {type: Address}
+        }
+      });
+      subject = Person.create({}, { "address_id": 1 });
+      spyOn(subject, 'updateWithApiData');
+      subject.get('address');
+    });
+
+    it("shouldn't call updateWithApiData when getting resource", function() {
+      expect(subject.updateWithApiData).not.toHaveBeenCalled();
+    });
+  });
+
   describe('has one embedded', function() {
     var data;
 

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -976,7 +976,12 @@
             instance = this._super.call(this, { data: data });
             this.identityMap.put(id, instance);
           } else {
-            instance.updateWithApiData(data);
+            var keys = Em.keys(data);
+            // Data.id is used by HasOneRemoteSchemaItem to request resource from identity map (no data is present),
+            // in this case avoid calling updateWithApiData (which fires didChange for all the resource properties)
+            if (!Em.empty(data) && Em.compare(keys, ['id']) !== 0) {
+              instance.updateWithApiData(data);
+            }
             // ignore incoming resourceState and id arguments
             delete options.resourceState;
             delete options.id;


### PR DESCRIPTION
Ember.Resource.HasOneRemoteSchemaItem getValue calls `get('type').create({}, {id: id})`, the second argument
overloading data to request the resource from the identity map. But it causes `updateWithDataApi` to be called,
which triggers didChange to all the resource properties. As that resource can potentially be shared by many other
ember resources (identity map), that causes undesired side effects.

/cc @jish @shajith 
