### PR TITLE
Correct scope in ResourceCollection#parse

### DIFF
--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -1200,7 +1200,7 @@
     parse: function(json) {
       this._resolveType();
       if (Ember.typeOf(this.type.parse) == 'function') {
-        return json.map(this.type.parse);
+        return json.map(this.type.parse, this);
       }
       else {
         return json;


### PR DESCRIPTION
@jish @shajith 

A small fix I uncovered while trying to get CLI tests running. I don't have a spec that catches this here, but the move to mocha (PR coming soon) will prevent regressions.
