### PR TITLE
Correct scope in ResourceCollection#parse (for real)

### DIFF
--- a/spec/javascripts/resourceCollectionSpec.js
+++ b/spec/javascripts/resourceCollectionSpec.js
@@ -4,6 +4,7 @@ describe('ResourceCollection', function() {
   var Model;
   beforeEach(function() {
     Model = Em.Resource.define({
+      schema: { name: String },
       url: '/url/from/resource'
     });
   });
@@ -19,6 +20,18 @@ describe('ResourceCollection', function() {
     }).create();
 
     expect(collection.resolveUrl()).toEqual('/url/from/collection');
+  });
+
+  describe('.parse', function() {
+    it("uses the model's parse method", function() {
+      Model.toString = function() { return 'Model'; };
+      Model.parse = function(json) { return { name: this + ' ' + json.name }; };
+      var collection = Em.ResourceCollection.create({
+        type: Model,
+        content: [ { name: 'instance' } ]
+      });
+      expect(collection.objectAt(0).get('name')).toBe('Model instance');
+    });
   });
 
   describe("when prepopulated", function() {

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -1200,7 +1200,7 @@
     parse: function(json) {
       this._resolveType();
       if (Ember.typeOf(this.type.parse) == 'function') {
-        return json.map(this.type.parse, this);
+        return json.map(this.type.parse, this.type);
       }
       else {
         return json;


### PR DESCRIPTION
@jish @shajith This is a follow-on to d4480bc31af32fea2f21aa689c208eac57e444c4

Originally, `ResourceCollection#parse` iterated over each item in the JSON array and called `this.type.parse` on it. Unfortunately, `this.type.parse` was the result of an `Ember.wrap` call, which sets `this._super` for inheritance support. Because we weren't passing a `this` pointer to `map`, it was being called on `window`, which caused the wrapped `_super` call to leak.

d4480bc31af32fea2f21aa689c208eac57e444c4 changed the `map` call to set the context of `this.type.parse` to `this`, but the `this` there is the `ResourceCollection` instance. Instead, it should be the model class. This commit changes the `this` pointer to `this.type`, which is the collection object's reference to its model type.

See also #41
