### PR TITLE
When generating *_id attribute for nested associations, add parent association as a dependency

### DIFF
--- a/spec/javascripts/schemaSpec.js
+++ b/spec/javascripts/schemaSpec.js
@@ -85,12 +85,19 @@ describe('schema definition', function() {
       expect(Model.schema.work_addr_id.get('type')).toBe(String);
     });
 
-    it('should create an *_id attribute for nested associations', function() {
-      expect(Model.schema.other_address).toBeDefined();
-      expect(Model.schema.other_address_id).toBeDefined();
-      expect(Model.schema.other_address_id instanceof Ember.Resource.HasOneNestedIdSchemaItem).toBe(true);
-      expect(Model.schema.other_address_id.get('association')).toBe(Model.schema.other_address);
-      expect(Model.schema.other_address_id.get('path')).toBe('other_address.id');
+    describe("with generated *_id attribute for nested associations", function() {
+      it('should be created', function() {
+        expect(Model.schema.other_address).toBeDefined();
+        expect(Model.schema.other_address_id).toBeDefined();
+        expect(Model.schema.other_address_id instanceof Ember.Resource.HasOneNestedIdSchemaItem).toBe(true);
+        expect(Model.schema.other_address_id.get('association')).toBe(Model.schema.other_address);
+        expect(Model.schema.other_address_id.get('path')).toBe('other_address.id');
+      });
+
+      it("should have parent association as a dependency", function() {
+        expect(Model.schema.other_address_id.get('dependencies')).toContain('other_address');
+        expect(Model.schema.other_address_id.get('dependencies')).toContain('_new_data');
+      });
     });
   });
 

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -322,14 +322,19 @@
   });
   Ember.Resource.HasOneNestedSchemaItem.reopenClass({
     create: function(name, schema) {
-      var definition = schema[name];
-      var instance = this._super.apply(this, arguments);
-      instance.set('path', definition.path || name);
+      var definition = schema[name],
+          instance   = this._super.apply(this, arguments),
+          path       = definition.path || name,
+          id_name    = name + '_id';
 
-      var id_name = name + '_id';
+      instance.set('path', path);
+
       if (!schema[id_name]) {
-        schema[id_name] = {type: Number, association: instance };
-        schema[id_name] = Ember.Resource.HasOneNestedIdSchemaItem.create(id_name, schema);
+        var dependencies   = { dependencies: [ path, '_new_data' ] },
+            NestedIdSchema = Ember.Resource.HasOneNestedIdSchemaItem.extend(dependencies);
+
+        schema[id_name] = { type: Number, association: instance };
+        schema[id_name] = NestedIdSchema.create(id_name, schema);
       }
 
       return instance;


### PR DESCRIPTION
E.g.:

``` javascript
Model = Ember.Resource.define({
  schema: {
    address: {type: Address, nested: true}
  }
});
```

It will generate `address_id`, but if `address.id` changes, it isn't propagated to `address_id` without the changes bellow.

@jish @shajith mind taking a look?
