### PR TITLE
deferedFetch -> deferredFetch

### DIFF
--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -768,7 +768,7 @@
 
       var self = this;
 
-      if (this.deferedFetch && !Ember.get(this, 'isExpired')) return this.deferedFetch;
+      if (this.deferredFetch && !Ember.get(this, 'isExpired')) return this.deferredFetch;
 
       self.willFetch.call(self);
       Ember.sendEvent(self, 'willFetch');
@@ -785,7 +785,7 @@
         ajaxOptions.data = {include: sideloads.join(",")};
       }
 
-      var result = this.deferedFetch = $.Deferred();
+      var result = this.deferredFetch = $.Deferred();
 
       Ember.Resource.ajax(ajaxOptions)
         .done(function(json) {
@@ -803,7 +803,7 @@
           result.reject.apply(result, arguments);
         }).
         always(function() {
-          self.deferedFetch = null;
+          self.deferredFetch = null;
         });
 
       return result.promise();
@@ -1142,11 +1142,11 @@
 
       var self = this;
 
-      if (this.deferedFetch && !Ember.get(this, 'isExpired')) return this.deferedFetch;
+      if (this.deferredFetch && !Ember.get(this, 'isExpired')) return this.deferredFetch;
 
       Ember.sendEvent(self, 'willFetch');
 
-      var result = this.deferedFetch = $.Deferred();
+      var result = this.deferredFetch = $.Deferred();
 
       this._fetch(ajaxOptions)
         .done(function(json) {


### PR DESCRIPTION
I noticed this typo when I was working with Ember Resource last week. The salient line of code is actually an [unchanged correct spelling of `deferredFetch`](https://github.com/zendesk/ember-resource/blob/fe969baaff1ee4f54e1eb9ef11dbbba02413f6df/src/ember-resource.js#L806) which will now start setting `deferredFetch` to null.

I'm currently not familiar enough to write a behavioral test that fails without this fix, but I'm happy to pair on one or dig further with some hints.

/cc @shajith @jish @dadah89 
