### PR TITLE
Skip deferred expiry if the object is deleted

### DIFF
--- a/spec/javascripts/lifecycleSpec.js
+++ b/spec/javascripts/lifecycleSpec.js
@@ -134,6 +134,15 @@ describe('Lifecycle', function() {
       });
     });
 
+    describe('on a destroyed object', function() {
+      beforeEach(function() {
+        person.destroy();
+      });
+
+      it('should not cause an error', function() {
+        expect(function() { person.expire(); }).to.not.throw();
+      });
+    });
   });
 
   describe('Given an object that observes `isFetchable`', function() {

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -668,6 +668,7 @@
 
       expire: function () {
         Ember.run.next(this, function () {
+          if(getPath(this, 'isDestroyed')) { return; }
           set(this, 'expireAt', new Date());
         });
       },


### PR DESCRIPTION
Calling `expire` on an Em.Resource instance only schedules the expiry
for the next run loop.

If at that time, the resource is destroyed, we
should skip changing `expireAt`, because it's an error to set properties
on destroyed objects.

@jish @jamesarosen @chrsjxn
