### PR TITLE
Makefile: some cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 DIST_JS = dist/ember-resource.js
 JSHINT  = ./node_modules/jshint/bin/jshint
+PHANTOM_JS = ./node_modules/mocha-phantomjs/bin/mocha-phantomjs
 
-dist: $(DIST_JS)
+dist: $(DIST_JS) $(JSHINT)
 	$(JSHINT) $<
 
 ci: dist test
@@ -10,16 +11,20 @@ $(DIST_JS): jshint
 	mkdir -p dist
 	cat src/vendor/lru.js src/base.js src/remote_expiry.js src/identity_map.js src/fetch.js src/ember-resource.js > $@
 
-jshint: npm_install
+jshint: $(JSHINT)
 	$(JSHINT) src/*.js src/vendor/*.js spec/javascripts/*Spec.js
 
 test: test-ember-09 test-ember-1
 
-test-ember-09: jshint npm_install
-	./node_modules/mocha-phantomjs/bin/mocha-phantomjs spec/runner.html
+test-ember-09: jshint $(PHANTOM_JS)
+	$(PHANTOM_JS) spec/runner.html
 
-test-ember-1: jshint npm_install
-	./node_modules/mocha-phantomjs/bin/mocha-phantomjs spec/runner-1.0.html
+test-ember-1: jshint $(PHANTOM_JS)
+	$(PHANTOM_JS) spec/runner-1.0.html
+
+$(JSHINT): npm_install
+
+$(PHANTOM_JS): npm_install
 
 npm_install:
 	npm install
@@ -30,4 +35,4 @@ clean:
 clobber: clean
 	rm -rf ./node_modules
 
-.PHONY: dist ci jshint test npm_install clean clobber
+.PHONY: dist ci jshint test test-ember-09 test-ember-1 npm_install clean clobber


### PR DESCRIPTION
- add `test-ember-09` and `test-ember-1` to `PHONY` to prevent Make from expecting those targets from creating files of the same names
- extract `PHANTOM_JS` executable path for reuse in the two test targets
- define `$(JSHINT)` and `$(PHANTOM_JS)` targets that depend on `npm_install` and use those targets as prerequisites where appropriate
