### PR TITLE
Resource states are readonly.

### DIFF
--- a/spec/javascripts/resourceSpec.js
+++ b/spec/javascripts/resourceSpec.js
@@ -255,6 +255,26 @@ describe('A Resource instance', function () {
         expect(model.get("name")).to.be.undefined;
       });
     });
-
   });
+
+  describe("resource states", function() {
+    beforeEach(function() {
+      model = Model.create();
+    });
+
+    it("should be readonly", function() {
+      [
+        'isSaving',
+        'isSavable',
+        'isFetched',
+        'isFetching',
+        'isInitializing',
+        'isFetchable'
+      ].forEach(function(state) {
+        model.set(state, 'custom_value');
+        expect(model.get(state)).not.to.equal('custom_value', 'fail message');
+      });
+    });
+  });
+
 });

--- a/spec/javascripts/saveSpec.js
+++ b/spec/javascripts/saveSpec.js
@@ -96,6 +96,12 @@ describe('Saving a resource instance', function() {
         server.respond();
         expect(resource.save()).to.be.ok;
       });
+
+      it("should not allow setting the value of isSaving", function() {
+        expect(resource.get('isSaving')).to.equal(false);
+        resource.set('isSaving', 'custom_value');
+        expect(resource.get('isSaving')).not.to.equal('custom_value');
+      });
     });
 
   });

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -633,24 +633,24 @@
         });
       },
 
-      isFetchable: Ember.computed(function() {
+      isFetchable: Ember.computed(function(key, value) {
         var state = getPath(this, 'resourceState');
         return state == Ember.Resource.Lifecycle.UNFETCHED || this.get('isExpired');
       }).volatile(),
 
-      isInitializing: Ember.computed('resourceState', function () {
+      isInitializing: Ember.computed('resourceState', function (key, value) {
         return (getPath(this, 'resourceState') || Ember.Resource.Lifecycle.INITIALIZING) === Ember.Resource.Lifecycle.INITIALIZING;
       }).cacheable(),
 
-      isFetching: Ember.computed('resourceState', function() {
+      isFetching: Ember.computed('resourceState', function(key, value) {
         return (getPath(this, 'resourceState')) === Ember.Resource.Lifecycle.FETCHING;
       }).cacheable(),
 
-      isFetched: Ember.computed('resourceState', function() {
+      isFetched: Ember.computed('resourceState', function(key, value) {
         return (getPath(this, 'resourceState')) === Ember.Resource.Lifecycle.FETCHED;
       }).cacheable(),
 
-      isSavable: Ember.computed('resourceState', function() {
+      isSavable: Ember.computed('resourceState', function(key, value) {
         var state = getPath(this, 'resourceState');
         var unsavableState = [
           Ember.Resource.Lifecycle.INITIALIZING,
@@ -662,7 +662,7 @@
         return state && !unsavableState.contains(state);
       }).cacheable(),
 
-      isSaving: Ember.computed('resourceState', function() {
+      isSaving: Ember.computed('resourceState', function(key, value) {
         return (getPath(this, 'resourceState')) === Ember.Resource.Lifecycle.SAVING;
       }).cacheable(),
 


### PR DESCRIPTION
@vcekov @shajith @jamesarosen @ebryn

In Ember 1.x the arity of a computed property function is checked. If it takes no arguments, it can be totally overwritten. E.g. a call to `set` will cause the property to _never_ be computed again.

However if you specify that you would like to accept two arguments `key`, and `value`, then the behavior is similar to that of `Ember 0.9.x`.
