### PR TITLE
If a resource is being fetched, .fetch should not return a resolved promise

### DIFF
--- a/spec/javascripts/fetchSpec.js
+++ b/spec/javascripts/fetchSpec.js
@@ -55,12 +55,15 @@ describe('deferred fetch', function() {
   describe('fetch() for resources being fetched', function() {
     it('resolves with the resource when the server responds', function() {
       var handler = sinon.spy(),
-          person = Person.create({id: 1});
+          person = Person.create({id: 1}),
+          promise1, promise2;
 
-      person.fetch();
+      promise1 = person.fetch();
       expect(person.get('isFetching')).to.be.ok;
 
-      person.fetch().done(handler);
+      promise2 = person.fetch().done(handler);
+
+      expect(promise1).to.equal(promise2);
 
       expect(handler.callCount).to.equal(0);
 

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -748,7 +748,9 @@
     fetch: function(ajaxOptions) {
       var sideloads;
 
-      if (this.deferredFetch && !getPath(this, 'isExpired')) return this.deferredFetch;
+      if (this.deferredFetch && !getPath(this, 'isExpired')) {
+        return this.deferredFetch.promise();
+      }
 
       if (!getPath(this, 'isFetchable')) return $.when(this.get('data'), this);
 


### PR DESCRIPTION
It should instead return the same deferred promise as the pending AJAX call.

Before:

``` javascript
a = resource.fetch();
b = resource.fetch();
a === b; //false
b.state(); //resolved
```

After:

``` javascript
a = resource.fetch();
b = resource.fetch();
a === b; //true
a.state(); //pending
```

@jish @jamesarosen @vcekov 
