### PR TITLE
Em.Resource.ajax properly supports a String argument

### DIFF
--- a/spec/javascripts/ajaxSpec.js
+++ b/spec/javascripts/ajaxSpec.js
@@ -1,0 +1,36 @@
+describe('Ember.Resource.ajax', function() {
+
+  beforeEach(function () {
+    sinon.stub($, "ajax", function() { return $.when(); });
+  });
+
+  afterEach(function () {
+    $.ajax.restore();
+  });
+
+  describe('when Ember.Resource.errorHandler is set', function() {
+
+    beforeEach(function() {
+      this.originalErrorHandler = Ember.Resource.errorHandler;
+      Ember.Resource.errorHandler = Em.K;
+    });
+
+    afterEach(function() {
+      Ember.Resource.errorHandler = this.originalErrorHandler;
+    });
+
+    it('passes an "error" option to $.ajax', function() {
+      Ember.Resource.ajax({ url: '/not/found/1' });
+      expect($.ajax.called).to.be.ok;
+      expect($.ajax.args[0][0].error).not.to.be.undefined;
+    });
+
+    it('passes an "error" option to $.ajax even if passed a String', function() {
+      Ember.Resource.ajax('/not/found/2');
+      expect($.ajax.called).to.be.ok;
+      expect($.ajax.args[0][0].error).not.to.be.undefined;
+    });
+
+  });
+
+});

--- a/spec/runner-1.0.html
+++ b/spec/runner-1.0.html
@@ -34,6 +34,7 @@
     <script type="text/javascript" src="../spec/javascripts/deepMergeSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/deepSetSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/destroySpec.js"></script>
+    <script type="text/javascript" src="../spec/javascripts/ajaxSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/fetchSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/identityMapSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/inheritanceSpec.js"></script>

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -33,6 +33,7 @@
     <script type="text/javascript" src="../spec/javascripts/deepMergeSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/deepSetSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/destroySpec.js"></script>
+    <script type="text/javascript" src="../spec/javascripts/ajaxSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/fetchSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/identityMapSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/inheritanceSpec.js"></script>

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -23,6 +23,10 @@
   var slice = Array.prototype.slice;
 
   exports.Ember.Resource.ajax = function(options) {
+    if (typeof options === "string") {
+      options = { url: '' + options };
+    }
+
     options.dataType = options.dataType || 'json';
     options.type     = options.type     || 'GET';
 


### PR DESCRIPTION
:bird: :bug: @zendesk/harrier

`jQuery.ajax('foo')` is shorthand for `jQuery.ajax({ url: 'foo' })`. Unfortunately, `Em.Resource.ajax('foo')` didn't work because it tried to manipulate the argument directly. This coerces the latter form to the former so Ember-Resource can set the correct options.
