### PR TITLE
Add Ember.Resource.find

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ci: dist test
 
 $(DIST_JS): jshint
 	mkdir -p dist
-	cat src/vendor/lru.js src/base.js src/remote_expiry.js src/identity_map.js src/fetch.js src/ember-resource.js src/debug_adapter.js > $@
+	cat src/vendor/lru.js src/base.js src/remote_expiry.js src/identity_map.js src/fetch.js src/find.js src/ember-resource.js src/debug_adapter.js > $@
 
 jshint: $(JSHINT)
 	$(JSHINT) src/*.js src/vendor/*.js spec/javascripts/*Spec.js

--- a/README.md
+++ b/README.md
@@ -159,7 +159,15 @@ MyApp.Comment = Ember.Resource.define({
 
 ### Fetching, Saving, and Destroying
 
-Fetch a resource with `fetch`:
+#### Fetch a resource with `find`:
+
+```javascript
+MyApp.Comment = Ember.Resource.define({...});
+MyApp.Comment.find(52).then(function(comment) {
+  // comment is an instance of MyApp.Comment
+});
+
+#### Fetch a resource with `fetch`:
 
 ```javascript
 MyApp.Comment = Ember.Resource.define({...});
@@ -169,10 +177,12 @@ MyApp.Comment.create({ id: 13 }).fetch();
 Calling `fetch` will issue an AJAX request to the resource's URL. It will
 return a [promise](http://api.jquery.com/category/deferred-object/). If the
 AJAX request responds normally, the promise will resolve with the API response
-and the resource. If it fails, the promised will fail with the AJAX error.
+and the resource. (Note that, for backwards-compatibility, this is different
+from `.find`, which resolves with just the model.) If it fails, the promise
+will fail with the AJAX error.
 
 The success callbacks for `save` and `destroyResource` have a slightly
-different signature. Those deferreds resolve with the resource and a String
+different signature. Those promises resolve with the resource and a String
 describing the action that occurred (one of
 `[ "create", "update", "destroy" ]`).
 

--- a/spec/javascripts/findSpec.js
+++ b/spec/javascripts/findSpec.js
@@ -1,0 +1,73 @@
+describe('Model.find', function() {
+  var Dish, server;
+
+  beforeEach(function() {
+    Dish = Ember.Resource.define({
+      url: '/dishes',
+      schema: {
+        id:       Number,
+        name:     String
+      }
+    });
+
+    server = sinon.fakeServer.create();
+  });
+
+  afterEach(function() {
+    server.restore();
+  });
+
+  describe('for a resource that exists', function() {
+    beforeEach(function() {
+      var json = { id: 48, name: 'sashimi platter' };
+
+      server.respondWith("GET", "/dishes/48",
+                         [200, { "Content-Type": "application/json" },
+                          JSON.stringify(json) ]);
+    });
+
+    it('returns a promise that resolves with the resource instance', function() {
+      var callback = sinon.spy();
+      Dish.find(48).then(callback);
+      server.respond();
+      expect(callback.called).to.be.ok;
+
+      var dish = callback.args[0][0];
+      expect(dish instanceof Dish).to.be.ok;
+      expect(dish.get('id')).to.equal(48);
+      expect(dish.get('name')).to.equal('sashimi platter');
+    });
+
+    it("caches outstanding requests", function() {
+      Dish.find(48);
+      Dish.find(48);
+      expect(server.requests.length).to.equal(1);
+    });
+
+    it("uses the class's identity map if present", function() {
+      var dish1, dish2;
+      Dish.find(48).then(function(dish) { dish1 = dish; });
+      server.respond();
+      Dish.find(48).then(function(dish) { dish2 = dish; });
+      expect(server.requests.length).to.equal(1);
+      expect(dish1).to.equal(dish2);
+    });
+  });
+
+  describe('for a resource that cannot be found', function() {
+    beforeEach(function() {
+      server.respondWith("GET", "/dishes/999",
+                         [404, { "Content-Type": "application/json" }, '""']);
+    });
+
+    it('returns a promise that rejects with the jqXHR', function() {
+      var onSuccess = sinon.spy(), onFail = sinon.spy();
+      Dish.find(999).then(onSuccess, onFail);
+      server.respond();
+      expect(onFail.called).to.be.ok;
+      var jqXHR = onFail.args[0][0];
+      expect(jqXHR.getResponseHeader('Content-Type')).to.equal('application/json');
+    });
+  });
+
+});

--- a/spec/runner-1.0.html
+++ b/spec/runner-1.0.html
@@ -13,6 +13,7 @@
     <script src="../src/remote_expiry.js"></script>
     <script src="../src/identity_map.js"></script>
     <script src="../src/fetch.js"></script>
+    <script src="../src/find.js"></script>
     <script src="../src/ember-resource.js"></script>
     <script src="../src/debug_adapter.js"></script>
     <link rel="stylesheet" href="../node_modules/mocha-phantomjs/node_modules/mocha/mocha.css" />
@@ -36,6 +37,7 @@
     <script type="text/javascript" src="../spec/javascripts/destroySpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/ajaxSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/fetchSpec.js"></script>
+    <script type="text/javascript" src="../spec/javascripts/findSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/identityMapSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/inheritanceSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/lifecycleSpec.js"></script>

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -12,6 +12,7 @@
     <script src="../src/remote_expiry.js"></script>
     <script src="../src/identity_map.js"></script>
     <script src="../src/fetch.js"></script>
+    <script src="../src/find.js"></script>
     <script src="../src/ember-resource.js"></script>
     <script src="../src/debug_adapter.js"></script>
     <link rel="stylesheet" href="../node_modules/mocha-phantomjs/node_modules/mocha/mocha.css" />
@@ -35,6 +36,7 @@
     <script type="text/javascript" src="../spec/javascripts/destroySpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/ajaxSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/fetchSpec.js"></script>
+    <script type="text/javascript" src="../spec/javascripts/findSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/identityMapSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/inheritanceSpec.js"></script>
     <script type="text/javascript" src="../spec/javascripts/lifecycleSpec.js"></script>

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -955,6 +955,8 @@
       return this;
     },
 
+    find: Ember.Resource.__find,
+
     // Create an instance of this resource. If `options` includes an
     // `id`, first check the identity map and return the existing resource
     // with that ID if found.
@@ -1249,6 +1251,8 @@
     isEmberResourceCollection: true,
     identityMapLimit: Ember.Resource.IdentityMap.DEFAULT_IDENTITY_MAP_LIMIT * 5,
     useIdentityMap: true,
+
+    find: Ember.Resource.__find,
 
     create: function(options) {
       options = options || {};

--- a/src/find.js
+++ b/src/find.js
@@ -1,0 +1,59 @@
+(function(exports) {
+
+  // CRUFT: when we move to ES6 modules, we can export this function
+  // directly instead of as Ember.Resource.__find.
+  exports.Ember.Resource.__find = function find(id) {
+    Ember.assert(this + '.find requires an ID', id != null);
+    initializeIdentityMap(this);
+    return findByConstructedInstance(this, id) ||
+           findByOutstandingRequest(this, id) ||
+           findByNewRequest(this, id);
+  };
+
+  function initializeIdentityMap(klass) {
+    // CRUFT: this is also in Ember.Resource.create.
+    if (klass.useIdentityMap && !klass.identityMap) {
+      klass.identityMap = new Ember.Resource.IdentityMap(klass.identityMapLimit);
+    }
+  }
+
+  function findByConstructedInstance(klass, id) {
+    var instance = klass.identityMap && klass.identityMap.get(id);
+    if (instance) { return $.when(instance); }
+  }
+
+  function findByOutstandingRequest(klass, id) {
+    var deferred = klass.identityMap && klass.identityMap.get('find:' + id);
+    if (deferred) { return deferred.promise(); }
+  }
+
+  function findByNewRequest(klass, id) {
+    var url = klass.resourceURL({ id: id });
+    // CRUFT: Ember.Resource.ajax returns a promise that
+    // has a "sticky" resolution context. That is, if you
+    // chain a .then onto it, it will invoke the .then
+    // at the right time, but future promises won't receive
+    // the return value of that .then. If we change to
+    // RSVP, we can just return .ajax(...).then(...);
+    var deferred = $.Deferred(),
+        cleanUpOustandingRequest = Em.K,
+        onFail = deferred.reject.bind(deferred);
+
+    function onSuccess(json) {
+      deferred.resolve(klass.create({}, json));
+    }
+
+    if (klass.identityMap) {
+      var key = 'find:' + id;
+      klass.identityMap.put(key, deferred);
+      cleanUpOustandingRequest = klass.identityMap.remove.bind(klass.identityMap, key);
+    }
+
+    Ember.Resource.ajax({ url: url })
+      .then(onSuccess, onFail)
+      .then(cleanUpOustandingRequest, cleanUpOustandingRequest);
+
+    return deferred.promise();
+  }
+
+}(this));


### PR DESCRIPTION
:bird: @zendesk/harrier

Previously, consumers of resource classes had to create an instance in order to fetch it:

```
Book.create({ id: 772 }).fetch()
```

This introduces Resource.find, which has two advantages:
1. it lazily constructs instances after the fetch succeeds
2. the promise it returns resolves with the model

The latter means that Resource.find is a great fit for Ember 1's `Ember.Route#model` hook.

There are several pieces of this code that deserve to be cleaned up in the future:
1. in order to put the code in a separate file, it currently exports the function as `Ember.Resource.__find`, where `Ember.Resource` and `Ember.ResourceCollection` pick it up. ES6 modules will make this much cleaner.
2. the `initializeIdentityMap` functionality already exists in `Ember.Resource.create`. ES6 modules could help here, as could a `NullIdentityMap` for classes that don't want a real identity map.
3. `findByNewRequest` creates its own Deferred and resolves it when the AJAX request resolves. According to the Promises/A spec, this should be done via a simple `.then` chain, but Ember.Resource.ajax returns a "greedy" promise that allows chaining, but doesn't let chained callbacks change the resolution arguments.

Resolves AI-1500
