### PR TITLE
ResourceCollection: similar didFetch/didFail Resource logic

### DIFF
--- a/spec/javascripts/fetchSpec.js
+++ b/spec/javascripts/fetchSpec.js
@@ -175,6 +175,12 @@ describe('deferred fetch', function() {
 
         expect(spy.calledWith(people, "read")).to.be.ok;
       });
+
+      it("collection should still be fetchable", function() {
+        people.fetch();
+        server.respond();
+        expect(people.get('isFetchable')).to.be.true;
+      });
     });
 
   });

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -1165,16 +1165,17 @@
           if(self.isFresh(parsedData)) {
             set(self, 'content', parsedData);
           }
+          Ember.Resource.sendEvent(self, 'didFetch');
           self.fetched().resolve(json, self);
           result.resolve(json, self);
         })
         .fail(function() {
+          Ember.Resource.sendEvent(self, 'didFail');
           var fetched = self.fetched();
           result.reject.apply(result, arguments);
           fetched.reject.apply(fetched, arguments);
         })
         .always(function() {
-          Ember.Resource.sendEvent(self, 'didFetch');
           self.deferredFetch = null;
         });
 


### PR DESCRIPTION
When fetch for an ResourceCollection fails, the object is being set as not fetchable anymore. The next fetch request, no API call will be made, returning a result from the identityMap instead (which will be empty) as if had succeeded, which can be specially bad if the second request was also suppose to fail.

/cc @shajith @jish @vcekov 
