### PR TITLE
Do not start the Ember Resource Clock automatically.

### DIFF
--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -712,7 +712,6 @@
 
     })
   };
-  Ember.Resource.Lifecycle.clock.start();
 
   Ember.Resource.reopen({
     isEmberResource: true,


### PR DESCRIPTION
This has been known to cause performance problems in large applications. We have been running with the clock disabled in production for a year now, and are convinced that performance is better without the clock.
