### PR TITLE
Check for JavaScript object types vs. Ember.Objects.

### DIFF
--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -11,9 +11,8 @@
     return Ember.typeOf(obj) === 'string';
   }
 
-  var objectType = 'object';
   function isObject(obj) {
-    return Ember.typeOf(obj) === objectType;
+    return Ember.typeOf(obj) === 'object';
   }
 
   // Used when evaluating schemas to turn a type String into a class.


### PR DESCRIPTION
@dadah89 @vcekov @shajith @jamesarosen 

`Ember.Object`s can not be cloned, therefore we need to check to make sure the object we are dealing with is actually a JavaScript object.
