### PR TITLE
Ember.Resource#fetch always returns a Promise

### DIFF
--- a/spec/javascripts/fetchSpec.js
+++ b/spec/javascripts/fetchSpec.js
@@ -93,6 +93,18 @@ describe('deferred fetch', function() {
       });
     });
 
+    describe('for resources with no resourceURL', function() {
+      it("returns a resolved promise", function() {
+        var handler = sinon.spy();
+        person.resourceURL = function() { return undefined; };
+
+        person.fetch().done(handler);
+        expect(handler.callCount).to.equal(1);
+        expect(handler.getCall(0).args[0].id).to.equal(person.get('id'));
+        expect(handler.getCall(0).args[1]).to.equal(person);
+      });
+    });
+
     describe('when there are errors', function() {
       beforeEach(function() {
         server.respondWith('GET', '/people/2', [422, {}, '[["foo", "bar"]]']);

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -763,7 +763,7 @@
 
       var url = this.resourceURL();
 
-      if (!url) return;
+      if (!url) return $.when(this.get('data'), this);
 
       var self = this;
 


### PR DESCRIPTION
Previously, `Ember.Resource#fetch` returned a Promise
- when the resource was already fetched
- when the resource was fetchable
- when the `isFetchable` was false

but returned `undefined` when `resourceURL()` returned a falsy value.

This ensures that case behaves like the `isFetchable === false` case.
