### PR TITLE
Use repo local version of Broccoli CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ node_js:
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm install -g broccoli-cli
 script: make ci

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 DIST_JS = dist/ember-resource.js
-JSHINT  = ./node_modules/jshint/bin/jshint
+
+BROCCOLI   = ./node_modules/broccoli-cli/bin/broccoli
+JSHINT     = ./node_modules/jshint/bin/jshint
 PHANTOM_JS = ./node_modules/mocha-phantomjs/bin/mocha-phantomjs
 
 dist: $(DIST_JS) $(JSHINT)
@@ -7,10 +9,9 @@ dist: $(DIST_JS) $(JSHINT)
 
 ci: dist test
 
-$(DIST_JS): jshint
-	@which broccoli > /dev/null || (echo "\n  Please install broccoli-cli: npm install -g broccoli-cli\n" && exit 1)
+$(DIST_JS): jshint $(BROCCOLI)
 	@rm -rf dist
-	@broccoli build dist
+	$(BROCCOLI) build dist
 	@echo "\n  Build successful!\n"
 
 jshint: $(JSHINT)
@@ -24,17 +25,17 @@ test-ember-current: jshint $(PHANTOM_JS)
 test-ember-next: jshint $(PHANTOM_JS)
 	$(PHANTOM_JS) spec/runner-next.html
 
+$(BROCCOLI): npm_install
 $(JSHINT): npm_install
-
 $(PHANTOM_JS): npm_install
 
 npm_install:
-	@npm install
+	npm install > /dev/null
 
 clean:
 	rm -rf ./dist
 
 clobber: clean
-	rm -rf ./node_modules
+	rm -rf ./node_modules ./tmp
 
 .PHONY: dist ci jshint test test-ember-09 test-ember-1 npm_install clean clobber

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "test": "make test"
   },
   "devDependencies": {
-    "mocha": "~1.9.0",
-    "chai": "~1.6.0",
-    "mocha-phantomjs": "~2.0.1",
-    "jshint": "2.5.0",
     "broccoli": "0.7.2",
+    "broccoli-cli": "^1.0.0",
     "broccoli-concat": "0.0.5",
+    "broccoli-merge-trees": "0.1.3",
     "broccoli-uglify-js": "0.1.2",
-    "broccoli-merge-trees": "0.1.3"
+    "chai": "~1.6.0",
+    "jshint": "2.5.0",
+    "mocha": "~1.9.0",
+    "mocha-phantomjs": "~2.0.1"
   }
 }


### PR DESCRIPTION
Previously, we would use any version of Broccoli CLI installed on the machine. Now, we only build using the version specified in `package.json`.