### PR TITLE
Ember.Resource.save() should always return a promise

### DIFF
--- a/spec/javascripts/saveSpec.js
+++ b/spec/javascripts/saveSpec.js
@@ -91,10 +91,10 @@ describe('Saving a resource instance', function() {
       });
 
       it('should not allow concurrent saves', function() {
-        expect(resource.save()).to.be.ok;
-        expect(resource.save()).to.equal(false);
+        expect(resource.save().state()).to.equal('pending');
+        expect(resource.save().state()).to.equal('rejected');
         server.respond();
-        expect(resource.save()).to.be.ok;
+        expect(resource.save().state()).to.equal('pending');
       });
 
       it("should not allow setting the value of isSaving", function() {

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -864,7 +864,9 @@
 
     save: function(options) {
       options = options || {};
-      if (!getPath(this, 'isSavable')) return false;
+      if (!getPath(this, 'isSavable')) {
+        return $.Deferred().reject(false);
+      }
 
       var ajaxOptions = {
         contentType: 'application/json',


### PR DESCRIPTION
As a consumer of ember-resource, I would expect save() to always return a promise. However, in the current implementation, save() returns false if the resource is not savable.

@shajith @jish 