### PR TITLE
Expose $.ajax abort functionality for Em.Resource.ajax calls

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -38,7 +38,7 @@
 
     var dfd = $.Deferred();
 
-    $.ajax(options).done(function() {
+    var ajax = $.ajax(options).done(function() {
       var args = slice.apply(arguments);
       Em.run(function() {
         dfd.resolveWith(options.context, args);
@@ -50,7 +50,9 @@
       });
     });
 
-    return dfd.promise();
+    return $.extend({
+      abort: ajax.abort
+    }, dfd.promise());
   };
 
 


### PR DESCRIPTION
@zendesk/orchid 

There are good use cases for having `Em.Resource.ajax` return cancelable promises.  This PR exposes the abort function of the underlying $.ajax object to allow the $.Deferred object to be cancelable.