### PR TITLE
New API Endpoint for Getting Promise and Ajax Objects

### DIFF
--- a/spec/javascripts/fetchSpec.js
+++ b/spec/javascripts/fetchSpec.js
@@ -223,4 +223,19 @@ describe('deferred fetch', function() {
     });
   });
 
+  describe('#cancelableAjax', function() {
+    beforeEach(function() {
+      server.respondWith('GET', '/autocomplete', [200, { "Content-Type": "application/json" }, '[]']);
+    });
+
+    it('returned object should contain a promise', function() {
+      var request = Em.Resource.cancelableAjax('/autocomplete');
+      expect(request.promise).to.be.defined;
+    });
+
+    it('returned object should contain an abort function', function() {
+      var request = Em.Resource.cancelableAjax('/autocomplete');
+      expect(request.abort).to.be.defined;
+    });
+  });
 });

--- a/spec/javascripts/fetchSpec.js
+++ b/spec/javascripts/fetchSpec.js
@@ -238,19 +238,25 @@ describe('deferred fetch', function() {
       expect(request.abort).to.be.defined;
     });
 
-    describe('using the returned promise', function() {
-      var spy, cb;
+    describe('using the returned promise and abort', function() {
+      var spy, request;
 
       beforeEach(function() {
         spy = sinon.spy();
-        cb = $.noop;
-        spy(cb);
+        request = Em.Resource.cancelableAjax('/autocomplete');
       });
 
       it('calls the done callback', function() {
-        Em.Resource.cancelableAjax('/autocomplete').promise.done(cb);
+        request.promise.done(spy);
         server.respond();
-        expect(spy.called);
+        expect(spy.called).to.be.true
+      });
+
+      it('does not call the done callback when aborted', function() {
+        request.promise.done(spy);
+        request.abort();
+        server.respond();
+        expect(spy.called).to.be.false
       });
     });
   });

--- a/spec/javascripts/fetchSpec.js
+++ b/spec/javascripts/fetchSpec.js
@@ -237,5 +237,21 @@ describe('deferred fetch', function() {
       var request = Em.Resource.cancelableAjax('/autocomplete');
       expect(request.abort).to.be.defined;
     });
+
+    describe('using the returned promise', function() {
+      var spy, cb;
+
+      beforeEach(function() {
+        spy = sinon.spy();
+        cb = $.noop;
+        spy(cb);
+      });
+
+      it('calls the done callback', function() {
+        Em.Resource.cancelableAjax('/autocomplete').promise.done(cb);
+        server.respond();
+        expect(spy.called);
+      });
+    });
   });
 });

--- a/spec/javascripts/fetchSpec.js
+++ b/spec/javascripts/fetchSpec.js
@@ -249,14 +249,14 @@ describe('deferred fetch', function() {
       it('calls the done callback', function() {
         request.promise.done(spy);
         server.respond();
-        expect(spy.called).to.be.true
+        expect(spy.called).to.be.true;
       });
 
       it('does not call the done callback when aborted', function() {
         request.promise.done(spy);
         request.abort();
         server.respond();
-        expect(spy.called).to.be.false
+        expect(spy.called).to.be.false;
       });
     });
   });

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -23,6 +23,10 @@
   var slice = Array.prototype.slice;
 
   exports.Ember.Resource.ajax = function(options) {
+    return Em.Resource.cancelableAjax(options).promise;
+  };
+
+  exports.Ember.Resource.cancelableAjax = function(options) {
     if (typeof options === "string") {
       options = { url: '' + options };
     }
@@ -38,7 +42,7 @@
 
     var dfd = $.Deferred();
 
-    $.ajax(options).done(function() {
+    var ajax = $.ajax(options).done(function() {
       var args = slice.apply(arguments);
       Em.run(function() {
         dfd.resolveWith(options.context, args);
@@ -50,7 +54,10 @@
       });
     });
 
-    return dfd.promise();
+    return {
+      abort:   ajax.abort,
+      promise: dfd.promise()
+    };
   };
 
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -38,7 +38,7 @@
 
     var dfd = $.Deferred();
 
-    var ajax = $.ajax(options).done(function() {
+    $.ajax(options).done(function() {
       var args = slice.apply(arguments);
       Em.run(function() {
         dfd.resolveWith(options.context, args);
@@ -50,9 +50,7 @@
       });
     });
 
-    return $.extend({
-      abort: ajax.abort
-    }, dfd.promise());
+    return dfd.promise();
   };
 
 


### PR DESCRIPTION
# New API Endpoint for Getting Promise and Ajax Objects

## Todo
+ [x] specs
+ [ ] plus one of team

@zendesk/orchid Let's not change the existing `Em.Resource.ajax` function.  Instead let's have another function that exposes the underlying ajax object, which itself can be aborted.
